### PR TITLE
 Implemented proper handling of newline characters in message

### DIFF
--- a/internal/whatsapp/whatsapp.go
+++ b/internal/whatsapp/whatsapp.go
@@ -274,7 +274,8 @@ func SendText(c echo.Context) error {
 
 	var reqSendMessage typWhatsApp.RequestSendMessage
 	reqSendMessage.RJID = strings.TrimSpace(c.FormValue("msisdn"))
-	reqSendMessage.Message = strings.TrimSpace(c.FormValue("message"))
+	message := strings.TrimSpace(c.FormValue("message"))
+	reqSendMessage.Message = strings.Replace(message, "\\n", "\n", -1)
 
 	if len(reqSendMessage.RJID) == 0 {
 		return router.ResponseBadRequest(c, "Missing Form Value MSISDN")


### PR DESCRIPTION
Added support: \n for line breaks.


example:
```js
curl -X 'POST' \
  'http://localhost:3000/api/v1/go-whatsapp-multidevice-rest/send/text' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer [REDACTED]' \
  -H 'Content-Type: multipart/form-data' \
  -F 'msisdn=[REDACTED]' \
  -F 'message=WhatsApp allows you to format text inside your messages. Please note, there’s no option to disable this feature. \n \n Note: New text formatting is only available on Web and Mac desktop. \n \n Italic \n To italicize your message, place an underscore on both sides of the text: _text_ \n \n Bold \n To bold your message, place an asterisk on both sides of the text: *text* \n \n Strikethrough \n To strikethrough your message, place a tilde on both sides of the text: \n ~text~ \n \n Monospace \n To monospace your message, place three backticks on both sides of the text: \n ```text``` \n \n Bulleted list \n To add a bulleted list to your message, place an asterisk or hyphen and a space before each word or sentence: \n * text \n * text \n Or \n  - text \n - text \n \n Numbered list \n To add a numbered list to your message, place a number, period, and space before each line of text: \n 1. text \n 2. text \n \n Quote \n To add a quote to your message, place an angle bracket and space before the text: \n > text \n \n Inline code \n To add inline code to your message, place a backtick on both sides of the message: \n `text`'
```

![output](https://github.com/dimaskiddo/go-whatsapp-multidevice-rest/assets/35617149/45453e79-f128-4859-99c7-f7ff4220646c)
